### PR TITLE
recovery:fstab: remove f2fs for cache

### DIFF
--- a/rootdir/fstab.qcom
+++ b/rootdir/fstab.qcom
@@ -9,7 +9,6 @@
 /dev/block/bootdevice/by-name/system    /system            ext4    ro,barrier=1                                    wait
 /dev/block/bootdevice/by-name/userdata  /data              f2fs    rw,noatime,nosuid,nodev,inline_xattr            wait,check,encryptable=/dev/block/bootdevice/by-name/bk1
 /dev/block/bootdevice/by-name/userdata  /data              ext4    nosuid,nodev,barrier=1,noauto_da_alloc,discard  wait,check,encryptable=/dev/block/bootdevice/by-name/bk1
-/dev/block/bootdevice/by-name/cache     /cache             f2fs    rw,noatime,nosuid,nodev,inline_xattr            wait,check
 /dev/block/bootdevice/by-name/cache     /cache             ext4    nosuid,nodev,barrier=1                          wait
 /dev/block/bootdevice/by-name/boot      /boot              emmc    defaults                                        defaults
 /dev/block/bootdevice/by-name/recovery  /recovery          emmc    defaults                                        defaults


### PR DESCRIPTION
fix Android Recovery cache mount

E:unknown fs_type "f2fs" for /cache

[recovery.img.tar.gz](https://github.com/Demon000/device_xiaomi_libra/files/1584863/recovery.img.tar.gz)

This is my repopick:https://gist.github.com/lrinQVQ/387d70b248d72f9069b2abefb08444ce
and
Power Cherry Pick:https://gist.github.com/lrinQVQ/d95ad52ca3871c0bbf5ed37b05af4300
https://gist.github.com/lrinQVQ/8e876c25771f946e38f05a1dd19e868f